### PR TITLE
Add more Eq and Show instances

### DIFF
--- a/Database/PostgreSQL/LibPQ.hsc
+++ b/Database/PostgreSQL/LibPQ.hsc
@@ -522,6 +522,7 @@ data TransactionStatus = TransIdle    -- ^ currently idle
                        | TransInTrans -- ^ idle, in a valid transaction block
                        | TransInError -- ^ idle, in a failed transaction block
                        | TransUnknown -- ^ the connection is bad
+                         deriving (Eq, Show)
 
 -- | Returns the current in-transaction status of the server.
 --
@@ -1055,6 +1056,8 @@ data FieldCode = DiagSeverity
                -- ^ The name of the source-code function reporting the
                -- error.
 
+                 deriving (Eq, Show)
+
 
 instance Enum FieldCode where
     toEnum (#const PG_DIAG_SEVERITY)           = DiagSeverity
@@ -1346,7 +1349,7 @@ data PrintOpt = PrintOpt {
     , poTableOpt   :: B.ByteString   -- ^ attributes for HTML table element
     , poCaption    :: B.ByteString   -- ^ HTML table caption
     , poFieldName  :: [B.ByteString] -- ^ list of replacement field names
-    }
+    } deriving Show
 
 
 defaultPrintOpt :: PrintOpt
@@ -1536,6 +1539,7 @@ data CopyInResult
                        --   write-ready (e.g. by using
                        --   'Control.Concurrent.threadWaitWrite'
                        --   on the 'socket') and try again.
+     deriving (Eq, Show)
 
 
 toCopyInResult :: CInt -> CopyInResult
@@ -1584,6 +1588,7 @@ data CopyOutResult
    | CopyOutError             -- ^ An error occurred (e.g. the connection is
                               --   not in the 'CopyOut' state).  Call
                               --   'errorMessage' for more information.
+     deriving Show
 
 -- | Receive raw @COPY@ data from the server during the 'CopyOut' state.
 --   The boolean parameter determines whether or not the call will block
@@ -1817,6 +1822,7 @@ isnonblocking connection = enumFromConn connection c_PQisnonblocking
 data FlushStatus = FlushOk
                  | FlushFailed
                  | FlushWriting
+                   deriving (Eq, Show)
 
 -- | Attempts to flush any queued output data to the server. Returns
 -- 'FlushOk' if successful (or if the send queue is empty),
@@ -1910,7 +1916,7 @@ data Notify = Notify {
       notifyRelname :: B.ByteString -- ^ notification channel name
     , notifyBePid   :: CPid         -- ^ process ID of notifying server process
     , notifyExtra   :: B.ByteString -- ^ notification payload string
-    }
+    } deriving Show
 
 instance Storable Notify where
   sizeOf _ = #{size PGnotify}


### PR DESCRIPTION
Some data types missed the first wave of Eq, Show instance additions (commit 16a7b14), either because I overlooked them, or they were added recently.  `Show` instances are really useful for testing stuff in GHCi.  `Eq` instances make testing a result against a single expected value more convenient (e.g. `if status == PQ.ConnectionOk`).

The procedure I used to decide what types get Eq and Show instances is:
- If the data type is exported and has at least one data constructor:
  - If it is purely an enumeration (no values attached to any data constructors), it gets an Eq instance.  For example CopyOutResult is not given an Eq instance because the CopyOutRow constructor has a ByteString parameter.
  - If its data constructors are exported, it gets a Show instance.

The decision to give result data types Eq instances is questionable.  If the Eq instance is omitted, the user is forced to handle all cases exhaustively (which is good, especially if the API changes in the future!).  However, I doubt the API will actually change much, and assuming users stick to comparisons of the form `x == NullaryThing` (and use case matching for more complex needs), the risk of API changes introducing bugs in peoples' code should be minimal.  I went ahead and added the Eq instances.
