### PR TITLE
Remove `programFindLocation` and `hookedPrograms` calls from Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -11,11 +11,7 @@ import Distribution.Verbosity
 import Data.Char (isSpace)
 import Data.List (dropWhile,reverse)
 
-import Control.Monad
-
 main = defaultMainWithHooks simpleUserHooks {
-  hookedPrograms = [pgconfigProgram],
-
   confHook = \pkg flags -> do
     lbi <- confHook simpleUserHooks pkg flags
     bi <- psqlBuildInfo lbi
@@ -26,17 +22,10 @@ main = defaultMainWithHooks simpleUserHooks {
     }
 }
 
-pgconfigProgram = (simpleProgram "pgconfig") {
-    programFindLocation = \verbosity -> do
-      pgconfig  <- findProgramLocation verbosity "pgconfig"
-      pg_config <- findProgramLocation verbosity "pg_config"
-      return (pgconfig `mplus` pg_config)
-  }
-
 psqlBuildInfo :: LocalBuildInfo -> IO BuildInfo
 psqlBuildInfo lbi = do
   (pgconfigProg, _) <- requireProgram verbosity
-                         pgconfigProgram (withPrograms lbi)
+                         (simpleProgram "pg_config") (withPrograms lbi)
   let pgconfig = rawSystemProgramStdout verbosity pgconfigProg
 
   incDir <- pgconfig ["--includedir"]


### PR DESCRIPTION
An upcoming version of the Cabal library will change the signature of the `programFindLocation` record field: https://github.com/haskell/cabal/commit/84c4ddce652cd8f60c57c940abfbe927bb03654f#L7L49

That change breaks this library's `Setup.hs`, which makes use of that record field. It looks to me like we can just remove the usage, which is much simpler than trying to use CPP to conditionally add a dummy argument.

The current `Setup.hs` checks for `pgconfig` and then `pg_config` on the path, and then uses that executable to find libpq's include/ and lib/ directories. To the best of my knowledge, `pgconfig` is not used by any recent version of PostgreSQL. (I've looked as far back as [version 7.2](http://www.postgresql.org/docs/7.2/static/app-pgconfig.html), released _12 years ago_.) Without needing that cascading path check, we can make do without the direct record field update.

I've also removed an unneeded use of the `hookedPrograms` record field in `main`. That made `pgconfig` available as a build tool to the .cabal file, which doesn't actually use it.
