### PR TITLE
Use pkg-config on Linux

### DIFF
--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -28,9 +28,12 @@ Library
                      , bytestring
 
   GHC-Options:       -Wall
-  Extra-Libraries: pq
-  if os(openbsd)
-    Extra-Libraries:  crypto ssl
+  if os(linux)
+    Pkgconfig-depends:   libpq
+  else
+    Extra-Libraries:     pq
+    if os(openbsd)
+      Extra-Libraries:     crypto ssl
 
   -- Other-modules:
   Build-tools:       hsc2hs


### PR DESCRIPTION
I thought this change would be an obvious improvement — and it is, on Debian derivatives.

Unfortunately, for reasons beyond my comprehension, RedHat derivatives do not ship a _pkg-config_ file for _libpq_. ([#977115](https://bugzilla.redhat.com/show_bug.cgi?id=977115))

I add the following `/usr/lib64/pkgconfig/libpq.pc` file as a workaround:

```
Name: libpq
Description: PostgreSQL libpq library
Version: 9
Cflags: -I/usr/include
Libs: -L/usr/lib64 -lpq
```

This enables applications such as [PostgREST](https://github.com/mietek/postgrest) to be installed with Halcyon in one command.

cc @begriffs