### PR TITLE
Add setSingleRowMode, via PQsetSingleRowMode

### DIFF
--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -1,5 +1,5 @@
 Name:                postgresql-libpq
-Version:             0.9.0.1
+Version:             0.9.1
 Synopsis:            low-level binding to libpq
 
 Description:         This is a binding to libpq: the C application

--- a/src/Database/PostgreSQL/LibPQ.hsc
+++ b/src/Database/PostgreSQL/LibPQ.hsc
@@ -164,6 +164,7 @@ module Database.PostgreSQL.LibPQ
     , isBusy
     , setnonblocking
     , isnonblocking
+    , setSingleRowMode
     , FlushStatus(..)
     , flush
 
@@ -959,6 +960,10 @@ data ExecStatus = EmptyQuery    -- ^ The string sent to the server was empty.
                 | NonfatalError -- ^ A nonfatal error (a notice or
                                 -- warning) occurred.
                 | FatalError    -- ^ A fatal error occurred.
+                | SingleTuple   -- ^ The PGresult contains a single result tuple
+                                -- from the current command. This status occurs
+                                -- only when single-row mode has been selected
+                                -- for the query.
                   deriving (Eq, Show)
 
 instance Enum ExecStatus where
@@ -970,6 +975,7 @@ instance Enum ExecStatus where
     toEnum (#const PGRES_BAD_RESPONSE)   = BadResponse
     toEnum (#const PGRES_NONFATAL_ERROR) = NonfatalError
     toEnum (#const PGRES_FATAL_ERROR)    = FatalError
+    toEnum (#const PGRES_SINGLE_TUPLE)   = SingleTuple
     toEnum _ = error "Database.PQ.Enum.ExecStatus.toEnum: bad argument"
 
     fromEnum EmptyQuery    = (#const PGRES_EMPTY_QUERY)
@@ -980,6 +986,7 @@ instance Enum ExecStatus where
     fromEnum BadResponse   = (#const PGRES_BAD_RESPONSE)
     fromEnum NonfatalError = (#const PGRES_NONFATAL_ERROR)
     fromEnum FatalError    = (#const PGRES_FATAL_ERROR)
+    fromEnum SingleTuple   = (#const PGRES_SINGLE_TUPLE)
 
 -- | Returns the result status of the command.
 resultStatus :: Result
@@ -1794,6 +1801,19 @@ isnonblocking :: Connection
 isnonblocking connection = enumFromConn connection c_PQisnonblocking
 
 
+-- | Select single-row mode for the currently-executing query.
+--
+-- This function can only be called immediately after PQsendQuery or one of its
+-- sibling functions, before any other operation on the connection such as
+-- PQconsumeInput or PQgetResult. If called at the correct time, the function
+-- activates single-row mode for the current query and returns 1. Otherwise the
+-- mode stays unchanged and the function returns 0. In any case, the mode
+-- reverts to normal after completion of the current query.
+setSingleRowMode :: Connection
+                 -> IO Bool
+setSingleRowMode connection = enumFromConn connection c_PQsetSingleRowMode
+
+
 data FlushStatus = FlushOk
                  | FlushFailed
                  | FlushWriting
@@ -2416,6 +2436,9 @@ foreign import ccall        "libpq-fe.h PQsetnonblocking"
 
 foreign import ccall unsafe "libpq-fe.h PQisnonblocking"
     c_PQisnonblocking :: Ptr PGconn -> IO CInt
+
+foreign import ccall unsafe "libpq-fe.h PQsetSingleRowMode"
+    c_PQsetSingleRowMode :: Ptr PGconn -> IO CInt
 
 foreign import ccall        "libpq-fe.h PQgetResult"
     c_PQgetResult :: Ptr PGconn -> IO (Ptr PGresult)


### PR DESCRIPTION
[Single row mode](http://www.postgresql.org/docs/9.3/static/libpq-single-row-mode.html) is a nice way to handle arbitrary queries with sane memory usage.

I have a test script, happy to Gist it if helpful. With `setSingleRowMode` after `sendQuery`, a simple `getResult` and print loop runs in constant space.