### PR TITLE
Add .h file to extra-source-files

### DIFF
--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -18,7 +18,7 @@ Copyright:           (c) 2010 Grant Monroe
                      (c) 2011 Leon P Smith
 Category:            Database
 Build-type:          Custom
--- Extra-source-files:
+Extra-source-files:  cbits/noticehandlers.h
 Cabal-version:       >=1.8
 
 -- If true,  use pkg-config,  otherwise use the pg_config based build


### PR DESCRIPTION
postgresql-libpq-0.9.1.0 from hackage fails to build because a header file isn't included in the distribution. (See: fpco/stackage/issues/715.) This patch adds it to the distribution.