### PR TITLE
Avoid segfaults on Windows when linking against official PostgreSQL distribution

### DIFF
--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -47,9 +47,17 @@ Library
   if flag(use-pkg-config)
     Pkgconfig-depends:   libpq
   else
-    Extra-Libraries:     pq
-    if os(openbsd)
-      Extra-Libraries:     crypto ssl
+    if os(windows)
+      -- Due to https://sourceware.org/bugzilla/show_bug.cgi?id=22948,
+      -- if we specify pq instead of libpq, then ld might link against
+      -- libpq.dll directly, which can lead to segfaults. As a temporary hack,
+      -- we force ld to link against the libpq.lib import library directly
+      -- by specifying libpq here.
+      Extra-Libraries:   libpq
+    else
+      Extra-Libraries:     pq
+      if os(openbsd)
+        Extra-Libraries:     crypto ssl
 
   -- Other-modules:
   Build-tools:       hsc2hs


### PR DESCRIPTION
Due to https://sourceware.org/bugzilla/show_bug.cgi?id=22948, if we specify `extra-libraries: pq` instead of `extra-libraries: libpq` within `postgresql-libpq.cabal`, then if you attempt to build `postgresql-libpq` against the official PostgreSQL distribution for Windows, then `ld` will link against `libpq.dll` directly (instead of the import library, `libpq.lib`). This can lead to segfaults, as `libpq.dll` will truncate R_X86_64_PC32 relocations.

As a (hopefully temporary) hack, we avoid this issue by forcing `ld` to link against the `libpq.lib` import library directly by specifying `extra-libraries: libpq` on Windows. I've confirmed that this works with both the official Windows PostgreSQL distribution as well as the MinGW-w64 version.

This should fix https://github.com/lpsmith/postgresql-libpq/issues/43.